### PR TITLE
Faster bind substscoped

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -1,8 +1,11 @@
-packages:
-  ../replib/RepLib/
-  ../replib/Unbound/
-  ../lennart-lambda/
+packages: .
+packages: ../RepLib
+packages: ../Unbound
 
+-- If you don't have replib checked out:
 
-
-
+-- source-repository-package
+--   type: git
+--   location: git@github.com:sweirich/replib.git
+--   tag: 0c7a400d2f275fe8ac8d946ef80f269e7f37c078
+--   subdir: RepLib Unbound

--- a/lib/SubstScoped.lhs
+++ b/lib/SubstScoped.lhs
@@ -58,27 +58,27 @@ This is a general purpose library for defining substitution for debruijn indices
 > ------------------------------------
 
 > data Bind a n where
->    Bind :: !(Sub a m (S n)) -> !(a m) -> Bind a n
+>    Bind :: !(Sub a m n) -> !(a (S m)) -> Bind a n
 
 > bind :: a (S n) -> Bind a n
 > bind x = Bind (Inc SZ) x
 > {-# INLINABLE bind #-}
 
 > unbind :: SubstC a => Bind a n -> a (S n)
-> unbind (Bind s a) = subst s a
+> unbind (Bind s a) = subst (lift s) a
 > {-# INLINABLE unbind #-}
 
 > instantiate :: SubstC a => Bind a n -> a n -> a n
-> instantiate (Bind s a) b = subst (comp s (single b)) a
+> instantiate (Bind s a) b = subst (Cons b s) a
 > {-# INLINABLE instantiate #-}
 
 > substBind :: SubstC a => Sub a n m -> Bind a n -> Bind a m
 >   -- use comp instead of :<>
-> substBind s2 (Bind s1 e) = Bind (comp s1 (lift s2)) e
+> substBind s2 (Bind s1 e) = Bind (comp s1 s2) e
 > {-# INLINABLE substBind #-}
 
 > instance (SubstC a, Eq (a (S n))) => Eq (Bind a n) where
->    (Bind s1 x) == (Bind s2 y) = subst s1 x == subst s2 y
+>    (Bind s1 x) == (Bind s2 y) = subst (lift s1) x == subst (lift s2) y
 
 > ------------------------------------
 


### PR DESCRIPTION
After trying to add scope+renaming, I found a way to change `SubstScoped` so it seems faster.

Whether this is an genuine improvement, I don't know. `rand` is slightly faster, lennart lambda is almost twice as fast.

### before

```
benchmarking rand/Scoped/
time                 659.4 μs   (658.5 μs .. 660.2 μs)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 659.4 μs   (658.8 μs .. 660.1 μs)
std dev              2.154 μs   (1.538 μs .. 3.051 μs)

benchmarking conv/Scoped
time                 20.38 μs   (20.26 μs .. 20.52 μs)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 20.43 μs   (20.37 μs .. 20.50 μs)
std dev              193.7 ns   (151.0 ns .. 256.4 ns)

benchmarking nf/Scoped/
time                 9.558 ms   (9.487 ms .. 9.604 ms)
                     0.999 R²   (0.999 R² .. 1.000 R²)
mean                 9.819 ms   (9.743 ms .. 9.945 ms)
std dev              269.3 μs   (175.7 μs .. 393.1 μs)

benchmarking aeq/Scoped
time                 24.19 μs   (24.04 μs .. 24.45 μs)
                     0.999 R²   (0.999 R² .. 1.000 R²)
mean                 24.13 μs   (24.05 μs .. 24.34 μs)
std dev              395.9 ns   (157.0 ns .. 771.6 ns)
variance introduced by outliers: 12% (moderately inflated)
```

### after

```
benchmarking rand/Scoped/
time                 579.2 μs   (574.8 μs .. 584.4 μs)
                     1.000 R²   (0.999 R² .. 1.000 R²)
mean                 583.8 μs   (581.4 μs .. 586.2 μs)
std dev              8.460 μs   (7.334 μs .. 10.70 μs)

benchmarking conv/Scoped
time                 20.80 μs   (20.71 μs .. 20.89 μs)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 20.82 μs   (20.73 μs .. 20.99 μs)
std dev              397.1 ns   (260.8 ns .. 706.6 ns)
variance introduced by outliers: 17% (moderately inflated)

benchmarking nf/Scoped/
time                 5.074 ms   (5.056 ms .. 5.092 ms)
                     1.000 R²   (0.999 R² .. 1.000 R²)
mean                 5.079 ms   (5.063 ms .. 5.101 ms)
std dev              55.84 μs   (40.42 μs .. 77.61 μs)

benchmarking aeq/Scoped
time                 23.88 μs   (23.77 μs .. 24.01 μs)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 23.88 μs   (23.80 μs .. 23.98 μs)
std dev              308.7 ns   (228.3 ns .. 517.1 ns)
```

